### PR TITLE
Corrette posizioni accordi in Gloria nell'alto dei cieli; seconde voci con \echo{}

### DIFF
--- a/archivio-canzoni/gloria_nell_alto_dei_cieli_gen_cerco_volto.tex
+++ b/archivio-canzoni/gloria_nell_alto_dei_cieli_gen_cerco_volto.tex
@@ -6,7 +6,7 @@
 %gruppo{Gloria}
 %momenti{Gloria}
 %identificatore{gloria_nell_alto_dei_cieli_gen_cerco_volto}
-%data_revisione{2011_12_31}
+%data_revisione{2020_11_01}
 %trascrittore{Francesco Endrici}
 \beginsong{Gloria nell'alto dei cieli}[by={Gen\ Verde}]
 \ifchorded
@@ -17,68 +17,58 @@
 \endverse
 \fi
 \beginchorus
-\[D]Gloria, \[G]gloria a \[B-7]Dio \[A]
-gloria, \[D]gloria nell'\[G]alto dei \[B-7]cieli. \[A]
-\[D]Pace in \[G]terra agli \[B-7]uomi\[A]ni
-di \[D]buona \[G]volon\[D]tà. \[G]
-\[D]\[G]Glo\[D]\[D]ria.
+Gl\[D]oria, gl\[G]oria a D\[B-7]io \[A]
+gloria, gl\[D]oria nell'\[G]alto dei ci\[B-7]el\[A]i. 
+P\[D]ace in t\[G]erra agli u\[B-7]omin\[A]i
+di bu\[D]ona v\[G]olont\[D]à. \[G]
+Gl\[D]\[G]ori\[D]\[D]a.
 \endchorus
 \beginverse
-\[A]Noi \[G]ti lo\[D]diamo, \[E-7]ti benedi\[D]ciamo
-ti \[G]ado\[D]riamo, glo\[C]rifichiamo \[D]Te
-\[G]ti ren\[D]diamo \[E-7]grazie
-per la \[D]tua immensa \[C]\[C]glo\[A4 A]ria.
-Si\[G]gnore \[D]Dio, \[E-7]glo\[D]ria! \[G]Re del \[D]cielo, \[C]glo\[D]ria!
-(Signore Dio re del cielo gloria)
-\[G]Dio \[D]Padre, \[E-7]Dio onnipo\[D]tente \[C]\[C]glo\[A]ria! \[E-]\[C]\[A]
-(Dio Padre gloria)
+N\[(B)]oi t\[G]i lodi\[D]amo, t\[E-7]i benedici\[D]amo
+ti \[G]adori\[D]amo, glor\[C]ifichiamo T\[D]e
+t\[G]i rendi\[D]amo gr\[E-7]azie
+per la t\[D]ua immensa gl\[C]\[C]ori\[A4]\[A]a.
+Sign\[G]ore D\[D]io, gl\[E-7]ori\[D]a! R\[G]e del ci\[D]elo, gl\[C]ori\[D]a!
+\echo{Signore Dio re del cielo gloria}
+D\[G]io P\[D]adre, D\[E-7]io onnipot\[D]ente gl\[C]\[C]ori\[A]a! \[(F#- D B)]
+\echo{Dio Padre gloria}
 \endverse
 \beginchorus
-\[D]Gloria, \[G]gloria a \[B-7]Dio \[A]
-(Gloria nell'alto dei cieli)
-gloria, \[D]gloria nell'\[G]alto dei \[B-7]cieli. \[A]
-(pace quaggiù sulla)
-\[D]Pace in \[G]terra agli \[B-7]uomi\[A]ni
-(terra pace agli uomini)
-di \[D]buona \[G]volon\[D]tà. \[G]
-(pace)
-\[D]\[G]Glo\[D]\[D]ria.
+Gl\[D]oria, gl\[G]oria a D\[B-7]io \[A]
+\echo{Gloria nell'alto dei cieli}
+gloria, gl\[D]oria nell'\[G]alto dei ci\[B-7]el\[A]i. 
+\echo{pace quaggiù sulla}
+P\[D]ace in t\[G]erra agli u\[B-7]omin\[A]i
+\echo{terra pace agli uomini}
+di bu\[D]ona v\[G]olont\[D]à. \[G]
+\echo{pace}
+Gl\[D]\[G]ori\[D]\[D]a.
 \endchorus
 \beginverse
-Si\[D]gnore, \[D]Figlio uni\[C]geni\[C]to, \[G]Gesù \[G]Cri\[D]sto.\[D]
-Si\[D]gnore, A\[D]gnello di \[C]Dio,\[C] \[G]Figlio del \[G]Pa\[D]dre,\[D]
-\[D]Tu che \[D]togli i pec\[C]cati del \[C]mondo,
-\[G]abbi pie\[G]tà di \[D]noi, \[D]
-\[D]tu che \[D]togli i pec\[C]cati del \[C]mondo,
-ac\[G]cogli la \[G]nostra \[D]suppli\[D]ca,
-\[D]tu che \[D]siedi alla \[C]destra del \[C]Padre.
-\[G]abbi pie\[G]tà di \[A4]noi. \[A]
+Sign\[D]ore, F\[D]iglio unig\[C]enit\[C]o, G\[G]esù Cr\[G]ist\[D]o. \[D]
+Sign\[D]ore, Agn\[D]ello di D\[C]i\[C]o, F\[G]iglio del P\[G]adr\[D]e, \[D]
+T\[D]u che t\[D]ogli i pecc\[C]ati del m\[C]ondo,
+\[G]abbi piet\[G]à di n\[D]oi, \[D]
+t\[D]u che t\[D]ogli i pecc\[C]ati del m\[C]ondo,
+acc\[G]ogli la n\[G]ostra s\[D]upplic\[D]a,
+t\[D]u che si\[D]edi alla d\[C]estra del P\[C]adre.
+\[G]abbi piet\[G]à di n\[A4]oi. \[A]
 \endverse
 \beginchorus
-\[D]Gloria, \[G]gloria a \[B-7]Dio \[A]
-gloria, \[D]gloria nell'\[G]alto dei \[B-7]cieli. \[A]
-\[D]Pace in \[G]terra agli \[B-7]uomi\[A]ni
-di \[D]buona \[G]volon\[D]tà. \[G]
-\[D]\[G]Glo\[D]\[D]ria.
-Gloria.
+Gl\[D]oria ...
 \endchorus
 \beginverse
-Per\[G]ché tu \[D]solo il \[E-7]Santo, il Si\[D]gnore
-(Gesù Cristo con il)
-tu \[G]solo l'al\[D]tissimo, \[C]Cristo Ge\[D]sù,
-(santo Spirito)
-\[G]con lo \[D]Spirito \[E-7]Santo
-(nella glo-)
-nella \[D]gloria del \[C]\[C]Pa\[A]dre \[E-]\[C]\[A]
-(ria gloria del Padre)
+Perch\[G]é tu s\[D]olo il S\[E-7]anto, il Sign\[D]ore
+\echo{Gesù Cristo con il}
+tu s\[G]olo l'alt\[D]issimo, Cr\[C]isto Ges\[D]ù,
+\echo{santo Spirito}
+c\[G]on lo Sp\[D]irito S\[E-7]anto
+\echo{nella glo}
+nella gl\[D]oria del P\[C]\[C]adr\[A]e \[(F#- D B)]
+\echo{ria gloria del Padre}
 \endverse
 \beginchorus
-\[D]Gloria, \[G]gloria a \[B-7]Dio \[A]
-gloria, \[D]gloria nell'\[G]alto dei \[B-7]cieli. \[A]
-\[D]Pace in \[G]terra agli \[B-7]uomi\[A]ni
-di \[D]buona \[G]volon\[D]tà. \[G]
-\[D]\[G]Glo\[D]\[D]ria.
+Gl\[D]oria ...
 \endchorus
 
 \endsong
-


### PR DESCRIPTION
Gli accordi sono stati riposizionati così da cadere sulla vocale di attacco dell'accordo.
Le seconde voci, anziché con le parentesi, sono state riportate con il comando \echo{}